### PR TITLE
Funciones para trabajar desde el local con archivos del server

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,10 @@ Imports:
     mgsub,
     stringr,
     tibble, 
-    dplyr
+    dplyr,
+    RCurl,
+    haven,
+    usethis
 Depends: 
     R (>= 2.10)
 Suggests: 

--- a/R/archivo_plano_srv.R
+++ b/R/archivo_plano_srv.R
@@ -1,0 +1,24 @@
+#' Leer archivos planos del server:
+#' @description
+#' Hace una llamada getUrl a la ruta indicada dentro de /srv/DataDNMYE/. Usarlo con read_csv o read_csv2 u otros.
+#'
+#' @param ruta Texto con la ruta específica del archivo a leer (ej.: "aerocomercial/anac/tabla_final.txt")
+#' @examples
+#' Devuelve las lineas del texto.
+#' archivo_plano_srv("turismo_internacional/termometro/perfiles_gasto.csv")
+#' Lee las lineas a un tibble.
+#' read_csv2(archivo_plano_srv("turismo_internacional/termometro/perfiles_gasto.csv"))
+#'
+#'@export
+
+archivo_plano_srv <- function(ruta) {
+
+  RCurl::getURL(url = paste0("sftp://",Sys.getenv("SRV_USER"),
+                      "@172.26.7.12/DataDNMYE/",
+                      ruta),
+         userpwd = paste0(Sys.getenv("SRV_USER"),":", Sys.getenv("SRV_CLAVE")),
+         dirlistonly = FALSE)
+
+}
+
+

--- a/R/ls_srv.R
+++ b/R/ls_srv.R
@@ -1,0 +1,25 @@
+#' Listar carpetas y archivos del server:
+#' @description
+#' Devuelve un vector con las ubicaciones en la ruta indicada dentro de /srv/DataDNMYE/.
+#'
+#' @param ruta Texto con la ruta específica del archivo a leer (ej.: "aerocomercial/anac/base_anac_agrupada.rds")
+#' @examples
+#' ls_srv()
+#' ls_srv("peajes")
+#'
+#'@export
+#'
+
+ls_srv <- function(ruta = NULL) {
+
+  sort(
+    strsplit(
+      as.vector(
+        RCurl::getURL(url = paste0("sftp://", Sys.getenv("SRV_USER"),
+                                   "@172.26.7.12/DataDNMYE/", ruta, "/"),
+                      userpwd = paste0(Sys.getenv("SRV_USER"),":", Sys.getenv("SRV_CLAVE")), .encoding = "UTF-8",
+                      dirlistonly = T)),
+      split = "\\n")[[1]])
+
+}
+

--- a/R/read_rds_srv.R
+++ b/R/read_rds_srv.R
@@ -1,0 +1,23 @@
+#' Leer archivos rds del server:
+#' @description
+#' Hace una conexión a la ruta indicada dentro de /srv/DataDNMYE/ y lee el archivo RDS con readRDS().
+#'
+#' @param ruta Texto con la ruta específica del archivo a leer (ej.: "aerocomercial/anac/base_anac_agrupada.rds")
+#' @examples
+#' read_rds_srv(ruta = "aerocomercial/anac/base_anac_agrupada.rds")
+#'
+#'@export
+#'
+
+read_rds_srv <- function(ruta) {
+  con <- RCurl::getBinaryURL(url = paste0("sftp://", Sys.getenv("SRV_USER"),
+                                   "@172.26.7.12/DataDNMYE/", ruta),
+                      userpwd = paste0(Sys.getenv("SRV_USER"),":", Sys.getenv("SRV_CLAVE")),
+                      dirlistonly = FALSE)
+
+  con <- gzcon(rawConnection(con))
+
+  on.exit(close(con))
+
+  readRDS(con)
+}

--- a/R/read_sav_srv.R
+++ b/R/read_sav_srv.R
@@ -1,0 +1,24 @@
+#' Leer archivos sav del server:
+#' @description
+#' Hace una conexión a la ruta indicada dentro de /srv/DataDNMYE/ y lee el archivo .sav con haven::read_sav().
+#'
+#' @param ruta Texto con la ruta específica del archivo a leer (ej.: "evyth/microdatos/evyth_microdatos.sav")
+#' @examples
+#' read_sav_srv("evyth/microdatos/evyth_microdatos.sav")
+#'
+#'@export
+#'
+
+
+read_sav_srv <- function(ruta) {
+  con <- RCurl::getBinaryURL(url = paste0("sftp://", Sys.getenv("SRV_USER"),
+                                   "@172.26.7.12/DataDNMYE/", ruta),
+                      userpwd = paste0(Sys.getenv("SRV_USER"),":", Sys.getenv("SRV_CLAVE")),
+                      dirlistonly = FALSE)
+
+  con <- gzcon(rawConnection(con))
+
+  on.exit(close(con))
+
+  haven::read_sav(con)
+}

--- a/R/set_user_srv.R
+++ b/R/set_user_srv.R
@@ -1,0 +1,16 @@
+#' Configurar usuario del server de dnmye:
+#' @description
+#' Guia para que el usuario configure sus credenciales en .Renviron".
+#' @export
+#'
+set_user_srv <- function() {
+  cat(
+    "###
+  Agregar al archivo .Renviron abierto el nombre de usuario y clave:
+  SRV_USER = \"nombredeusuario\"
+  SRV_CLAVE = \"clavedeusuario\"
+###
+  Guardar archivo y reiniciar sesion.\n")
+  usethis::edit_r_environ()
+
+}

--- a/tests/testthat/test-limpiar_texto.R
+++ b/tests/testthat/test-limpiar_texto.R
@@ -1,4 +1,4 @@
-test_that("multiplication works", {
+test_that("limpiar texto", {
   expect_equal(limpiar_texto("TéxTÔ con una Ñ?!"), "texto con una n")
   expect_equal(limpiar_texto("TéxTÔ con una Ñ?!", enie = F), "texto con una ñ")
 })

--- a/tests/testthat/test-numero_en_palabras.R
+++ b/tests/testthat/test-numero_en_palabras.R
@@ -1,4 +1,4 @@
-test_that("multiplication works", {
+test_that("numeros en palabras", {
   expect_equal(numeros_en_palabras("25 de mayo"), "veinticinco de mayo")
   expect_equal(numeros_en_palabras("6 de abril del 98"), "seis de abril del noventa y ocho")
 })

--- a/tests/testthat/test-remover_tildes.R
+++ b/tests/testthat/test-remover_tildes.R
@@ -1,3 +1,3 @@
-test_that("multiplication works", {
+test_that("remover tildes", {
   expect_equal(remover_tildes("ÿúòâ"), "yuoa")
 })


### PR DESCRIPTION
1. set_user_srv() es solo para guiar al usuario al configurar las credenciales en .Renviron
2. archivo_plano_srv() devuelve las lineas de una archivo plano en el server, es para usar junto a read.csv y otras funciones de lectura de archivos plano
3. read_rds_srv() y read_sav_srv() leen especificamente esos tipo de archivos mediante gzcon() y getBinaryURL()